### PR TITLE
Remove images from Berliner Zeitung articles

### DIFF
--- a/app/services/get_berliner_zeitung_article_content.rb
+++ b/app/services/get_berliner_zeitung_article_content.rb
@@ -10,7 +10,9 @@ class GetBerlinerZeitungArticleContent
 
     title = page.at(".a-storyhead")
     leading_content = page.at(".a-storylead")
+
     content = page.at(".main-content")
+    content.css("img")&.remove
 
     "#{title} #{leading_content} #{content.inner_html}"
   end

--- a/spec/services/get_berliner_zeitung_article_content_spec.rb
+++ b/spec/services/get_berliner_zeitung_article_content_spec.rb
@@ -39,4 +39,14 @@ RSpec.describe GetBerlinerZeitungArticleContent do
       "Hasen sind lernfähig und sehen Menschen in der Stadt nicht als Feinde an"
     )
   end
+
+  it "removes images" do
+    http_client = MockHTTPClient.new("berliner-zeitung-article.html")
+    service = GetBerlinerZeitungArticleContent.new(http_client: http_client)
+    result = service.call(
+      "https://www.berliner-zeitung.de/mensch-metropole/berliner-forscher-bitten-zu-ostern-zur-hasenjagd-li.150204"
+    )
+
+    expect(result).not_to include("<img")
+  end
 end


### PR DESCRIPTION
<img> tags without "src" attribute break Kindle conversion